### PR TITLE
More flexible kubernetes-kubectl-await

### DIFF
--- a/kubernetes-vars.el
+++ b/kubernetes-vars.el
@@ -7,6 +7,11 @@
   :group 'tools
   :prefix "kubernetes-")
 
+(defcustom kubernetes-kubectl-timeout-seconds 25
+  "How long to wait for kubectl before giving up."
+  :group 'kubernetes
+  :type 'integer)
+
 (defcustom kubernetes-kubectl-executable "kubectl"
   "The kubectl command used for Kubernetes commands."
   :group 'kubernetes

--- a/test/kubernetes-kubectl-test.el
+++ b/test/kubernetes-kubectl-test.el
@@ -85,6 +85,18 @@ will be mocked."
   (let ((state '((kubectl-flags . ("--foo=bar" "-x")))))
     (should (equal '("--foo=bar" "-x") (kubernetes-kubectl--flags-from-state state)))))
 
+(ert-deftest kubernetes-kubectl-test--await-nohang ()
+  (should (let ((kubernetes-kubectl-timeout-seconds 3))
+            (kubernetes-kubectl-await
+             (lambda (&rest callbacks) (funcall (car callbacks)))
+             (lambda (&rest _args) t)))))
+
+(ert-deftest kubernetes-kubectl-test--await-hang ()
+  (should-not (let ((kubernetes-kubectl-timeout-seconds 3))
+                (kubernetes-kubectl-await
+                 #'ignore
+                 (lambda (&rest _args) t)))))
+
 (ert-deftest kubernetes-kubectl-test--running-kubectl-works ()
   (if (executable-find kubernetes-kubectl-executable)
       (let ((result-string (kubernetes-kubectl-await-on-async kubernetes-kubectl-test-props nil


### PR DESCRIPTION
The existing `kubernetes-kubectl-await-on-async` is not quite general
enough, and hangs forever on an error.

New `kubernetes-kubectl-await` is generalized so that it takes an
arbitrary command and callbacks set (instead of props, state, and an
on-success callback).  It will also give up after
`kubernetes-kubectl-timeout-seconds`.